### PR TITLE
Add ability to override date and time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ You can define your favourite main color if you don't like any of above.
 set -g @tmux_power_theme '#483D8B' # dark slate blue
 ```
 
+You can change the date and time formats using strftime:
+
+```tmux
+set -g @tmux_power_date_format '%F'
+set -g @tmux_power_time_format '%T'
+```
+
 You can also customize the icons:
 
 ```tmux

--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -31,6 +31,8 @@ show_upload_speed="$(tmux_get @tmux_power_show_upload_speed false)"
 show_download_speed="$(tmux_get @tmux_power_show_download_speed false)"
 show_web_reachable="$(tmux_get @tmux_power_show_web_reachable false)"
 prefix_highlight_pos=$(tmux_get @tmux_power_prefix_highlight_pos)
+time_format=$(tmux_get @tmux_power_time_format '%T')
+date_format=$(tmux_get @tmux_power_date_format '%F')
 # short for Theme-Colour
 TC=$(tmux_get '@tmux_power_theme' 'gold')
 case $TC in
@@ -117,7 +119,7 @@ tmux_set status-left "$LS"
 tmux_set status-right-bg "$G04"
 tmux_set status-right-fg "G12"
 tmux_set status-right-length 150
-RS="#[fg=$TC,bg=$G06] $time_icon %T #[fg=$TC,bg=$G06]$left_arrow_icon#[fg=$G04,bg=$TC] $date_icon %F "
+RS="#[fg=$TC,bg=$G06] $time_icon $time_format #[fg=$TC,bg=$G06]$left_arrow_icon#[fg=$G04,bg=$TC] $date_icon $date_format "
 if "$show_download_speed"; then
     RS="#[fg=$G05,bg=$BG]$left_arrow_icon#[fg=$TC,bg=$G05] $download_speed_icon#{download_speed} #[fg=$G06,bg=$G05]$left_arrow_icon$RS"
 fi


### PR DESCRIPTION
Adds two new varables: `@tmux_power_date_format` & `@tmux_power_time_format`
Allows you to customize the strftime formatting for the date and time sections.

The default is left as it was before if nothing is provided.

Created this as I preferred a different date and time format than the default.