### PR TITLE
Support for customizing statusbar

### DIFF
--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -15,7 +15,7 @@ tmux_get() {
 # $1: option
 # $2: value
 tmux_set() {
-    tmux set-option -gq "$1" "$2"
+    tmux set-option -goq "$1" "$2"
 }
 
 # Options


### PR DESCRIPTION
"The -o flag prevents setting an option that is already set"

This allows the customization of different plugins and colors on the status bar, by allowing the user to override the options specified in this tmux config file.