### PR TITLE
Revert "Support for customizing statusbar"

### DIFF
--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -15,7 +15,7 @@ tmux_get() {
 # $1: option
 # $2: value
 tmux_set() {
-    tmux set-option -goq "$1" "$2"
+    tmux set-option -gq "$1" "$2"
 }
 
 # Options


### PR DESCRIPTION
Reverts wfxr/tmux-power#18

Hi @j-chao I found the theme does not work anymore after this seemingly minor change. So I temporarily reverted it to avoid affecting more users, until we find where the problem is.

Here is my tmux config: https://github.com/wfxr/dotfiles/blob/master/tmux/tmux.conf

Before the change:

![image](https://user-images.githubusercontent.com/6105425/132992472-30a89bec-f196-4193-ba59-db4b2b1f5c22.png)

After the change:
![image](https://user-images.githubusercontent.com/6105425/132992487-47ae9298-c3ff-45fa-9a5b-577480222f1e.png)
