### PR TITLE
Fix: Missing left arrow icon next to clock

### DIFF
--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -119,9 +119,9 @@ tmux_set status-left "$LS"
 tmux_set status-right-bg "$G04"
 tmux_set status-right-fg "G12"
 tmux_set status-right-length 150
-RS="#[fg=$TC,bg=$G06] $time_icon $time_format #[fg=$TC,bg=$G06]$left_arrow_icon#[fg=$G04,bg=$TC] $date_icon $date_format "
+RS="#[fg=$G06]$left_arrow_icon#[fg=$TC,bg=$G06] $time_icon $time_format #[fg=$TC,bg=$G06]$left_arrow_icon#[fg=$G04,bg=$TC] $date_icon $date_format "
 if "$show_download_speed"; then
-    RS="#[fg=$G05,bg=$BG]$left_arrow_icon#[fg=$TC,bg=$G05] $download_speed_icon #{download_speed} #[fg=$G06,bg=$G05]$left_arrow_icon$RS"
+    RS="#[fg=$G05,bg=$BG]$left_arrow_icon#[fg=$TC,bg=$G05] $download_speed_icon #{download_speed} $RS"
 fi
 if "$show_web_reachable"; then
     RS=" #{web_reachable_status} $RS"


### PR DESCRIPTION
Before fix:
![2022-03-06_21-38](https://user-images.githubusercontent.com/1824874/156941593-e9b7ff43-8fcf-4d8c-b633-709f830f87b0.png)

After fix:
![2022-03-06_21-37](https://user-images.githubusercontent.com/1824874/156941594-0476162a-4491-4709-95ed-d8d4c7cf1d7f.png)

Thank you for this wonderful theme and keep up the great work! 😉 