### PR TITLE
fix: set pane-active-border-style background to default

### DIFF
--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -148,7 +148,7 @@ tmux_set window-status-current-statys "fg=$TC,bg=$BG"
 tmux_set pane-border-style "fg=$G07,bg=default"
 
 # Active pane border
-tmux_set pane-active-border-style "fg=$TC,bg=$BG"
+tmux_set pane-active-border-style "fg=$TC,bg=default"
 
 # Pane number indicator
 tmux_set display-panes-colour "$G07"


### PR DESCRIPTION
This changes the **pane-active-border-style** background from "$BG" back to "default".

This was changed from "default" to "$BG" in the following commit, and seems like it could have been a typo (but I might be wrong).
* https://github.com/wfxr/tmux-power/commit/367dfb53ad0083e5779a0ddb51a3f2d4903f997a - Refactor & fix on style.

That commit made the following change
```
 # Active pane border
-tmux_set pane-active-border-fg $TC
-tmux_set pane-active-border-bg default
+tmux_set pane-active-border-style fg=$TC bg=$BG
```

Close & ignore this PR if that change was intentional.  Thanks!

--------------------

before (bg=$BG)
![tmux-pane-before](https://user-images.githubusercontent.com/8094490/205525809-2acdbfed-6743-440b-b1ab-154bec3c3905.png)

after (bg=default)
![tmux-pane-after](https://user-images.githubusercontent.com/8094490/205525839-ff301711-2cda-4597-bcbc-1f774ee2bff5.png)
