### PR TITLE
feat: add additional color customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,29 @@ something like [pywal](https://github.com/dylanaraps/pywal) for instance.
 
 ### ⚙  Customizing
 
-You can define your favourite main color if you don't like any of above.
+You can define your favourite colors if you don't like any of above.
 
 ```tmux
+# Main color
 set -g @tmux_power_theme '#483D8B' # dark slate blue
+
+# Foreground and background
+set -g @tmux_power_fg '#ffffff' # white
+set -g @tmux_power_bg '#000000' # black
+
+# Greys
+set -g @tmux_power_g01 "#080808"
+set -g @tmux_power_g02 "#121212"
+set -g @tmux_power_g03 "#1c1c1c"
+set -g @tmux_power_g04 "#262626"
+set -g @tmux_power_g05 "#303030"
+set -g @tmux_power_g06 "#3a3a3a"
+set -g @tmux_power_g07 "#444444"
+set -g @tmux_power_g08 "#4e4e4e"
+set -g @tmux_power_g00 "#585858"
+set -g @tmux_power_g10 "#626262"
+set -g @tmux_power_g11 "#6c6c6c"
+set -g @tmux_power_g12 "#767676"
 ```
 
 You can change the date and time formats using strftime:

--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -65,21 +65,21 @@ case $TC in
         ;;
 esac
 
-G01=#080808 #232
-G02=#121212 #233
-G03=#1c1c1c #234
-G04=#262626 #235
-G05=#303030 #236
-G06=#3a3a3a #237
-G07=#444444 #238
-G08=#4e4e4e #239
-G09=#585858 #240
-G10=#626262 #241
-G11=#6c6c6c #242
-G12=#767676 #243
+G01=$(tmux_get @tmux_power_g01 "#080808") #232
+G02=$(tmux_get @tmux_power_g02 "#121212") #233
+G03=$(tmux_get @tmux_power_g03 "#1c1c1c") #234
+G04=$(tmux_get @tmux_power_g04 "#262626") #235
+G05=$(tmux_get @tmux_power_g05 "#303030") #236
+G06=$(tmux_get @tmux_power_g06 "#3a3a3a") #237
+G07=$(tmux_get @tmux_power_g07 "#444444") #238
+G08=$(tmux_get @tmux_power_g08 "#4e4e4e") #239
+G09=$(tmux_get @tmux_power_g00 "#585858") #240
+G10=$(tmux_get @tmux_power_g10 "#626262") #241
+G11=$(tmux_get @tmux_power_g11 "#6c6c6c") #242
+G12=$(tmux_get @tmux_power_g12 "#767676") #243
 
-FG="$G10"
-BG="$G04"
+FG=$(tmux_get @tmux_power_fg "$G10")
+BG=$(tmux_get @tmux_power_bg "$G04")
 
 # Status options
 tmux_set status-interval 1


### PR DESCRIPTION
This PR adds additional color customization options which include the foreground, background, and the greys.
The defaults are used if they're not set.

List of added settings:
- tmux_power_fg
- tmux_power_bg
- tmux_power_g01
- tmux_power_g02
- tmux_power_g03
- tmux_power_g04
- tmux_power_g05
- tmux_power_g06
- tmux_power_g07
- tmux_power_g08
- tmux_power_g00
- tmux_power_g10
- tmux_power_g11
- tmux_power_g12