### PR TITLE
Fix bg/fg colors for non-current windows

### DIFF
--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -132,7 +132,7 @@ fi
 tmux_set status-right "$RS"
 
 # Window status
-tmux_set window-status-format " #I:#W#F "
+tmux_set window-status-format "#[fg=$G12,bg=$BG,bold] #I:#W#F #[nobold]"
 tmux_set window-status-current-format "#[fg=$BG,bg=$G06]$right_arrow_icon#[fg=$TC,bold] #I:#W#F #[fg=$G06,bg=$BG,nobold]$right_arrow_icon"
 
 # Window separator


### PR DESCRIPTION
Sometimes, wrong colors were appearing in my Tmux for windows different to the current one. At first I thought it was related with tmux-net-speed plugin, but when disabled, the issue remained. I'm using G12 for foreground color and bold text, and then unsetting the bold text.