### PR TITLE
fix: set window-status-bell-style to prevent default reverse highlighting

### DIFF
--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -154,6 +154,7 @@ tmux_set window-status-current-format "#[fg=$G0,bg=$TC]$rarrow#[fg=$G0,bg=$TC,$b
 tmux_set window-status-style          "fg=$TC,bg=$G0,none"
 tmux_set window-status-last-style     "fg=$TC,bg=$G0,$bold_prefix"
 tmux_set window-status-activity-style "fg=$TC,bg=$G0,$bold_prefix"
+tmux_set window-status-bell-style     "fg=$TC,bg=$G0,$bold_prefix"
 
 # Window separator
 tmux_set window-status-separator ""


### PR DESCRIPTION
## Summary

- Add explicit `window-status-bell-style` setting to match `window-status-activity-style`
- Without this, tmux uses its default `reverse` style for bell alerts, causing the window status section to appear with swapped fg/bg colors — visually similar to the active window highlight, but with un-highlighted arrow separators

## Test plan

- [ ] Trigger a bell event in a non-active window (e.g., `echo -e '\a'`) and verify the status bar no longer shows reversed/highlighted colors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling for terminal bell notifications with improved color configuration and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->