### PR TITLE
improve: minor cleanups and configurable status-interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ set -g @tmux_power_theme 'snow'
 ```bash
 set -g @tmux_power_theme 'forest'
 ```
-Violet
+#### Violet
 ```bash
 set -g @tmux_power_theme 'violet'
 ```
@@ -118,6 +118,8 @@ set -g @tmux_power_show_host    true
 set -g @tmux_power_show_session true
 
 set -g @tmux_power_use_bold     true
+
+set -g @tmux_power_status_interval 1  # status bar refresh interval in seconds
 ```
 
 *The default icons use glyphs from [nerd-fonts](https://github.com/ryanoasis/nerd-fonts).*

--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -20,10 +20,10 @@ tmux_set() {
 }
 
 # Options
-rarrow=$(tmux_get '@tmux_power_right_arrow_icon' '')
-larrow=$(tmux_get '@tmux_power_left_arrow_icon' '')
-upload_speed_icon=$(tmux_get '@tmux_power_upload_speed_icon' '󰕒')
-download_speed_icon=$(tmux_get '@tmux_power_download_speed_icon' '󰇚')
+rarrow="$(tmux_get '@tmux_power_right_arrow_icon' '')"
+larrow="$(tmux_get '@tmux_power_left_arrow_icon' '')"
+upload_speed_icon="$(tmux_get '@tmux_power_upload_speed_icon' '󰕒')"
+download_speed_icon="$(tmux_get '@tmux_power_download_speed_icon' '󰇚')"
 session_icon="$(tmux_get '@tmux_power_session_icon' '')"
 user_icon="$(tmux_get '@tmux_power_user_icon' '')"
 time_icon="$(tmux_get '@tmux_power_time_icon' '')"
@@ -34,9 +34,9 @@ show_session="$(tmux_get @tmux_power_show_session true)"
 show_upload_speed="$(tmux_get @tmux_power_show_upload_speed false)"
 show_download_speed="$(tmux_get @tmux_power_show_download_speed false)"
 show_web_reachable="$(tmux_get @tmux_power_show_web_reachable false)"
-prefix_highlight_pos=$(tmux_get @tmux_power_prefix_highlight_pos)
-time_format=$(tmux_get @tmux_power_time_format '%T')
-date_format=$(tmux_get @tmux_power_date_format '%F')
+prefix_highlight_pos="$(tmux_get @tmux_power_prefix_highlight_pos)"
+time_format="$(tmux_get @tmux_power_time_format '%T')"
+date_format="$(tmux_get @tmux_power_date_format '%F')"
 
 use_bold="$(tmux_get @tmux_power_use_bold true)"
 
@@ -87,7 +87,7 @@ else
 fi
 
 # Status options
-tmux_set status-interval 1
+tmux_set status-interval "$(tmux_get @tmux_power_status_interval 1)"
 tmux_set status on
 
 # Basic status bar colors


### PR DESCRIPTION
## Summary
- Fix README: add missing `####` heading for Violet theme
- Make `status-interval` configurable via `@tmux_power_status_interval` (default: 1), so users don't need to worry about load order to override it
- Document the new `@tmux_power_status_interval` option in README
- Unify quoting style for command substitutions

## Test plan
- [ ] Verify Violet theme heading renders correctly in README
- [ ] Test `set -g @tmux_power_status_interval 5` works as expected
- [ ] Verify default behavior (interval=1) is unchanged when option is not set