### PR TITLE
perf: avoid temp file by using tmux source-file stdin

### DIFF
--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -19,11 +19,14 @@ tmux_set() {
 # Flush all accumulated set-option commands at once (single fork)
 tmux_flush() {
     [[ -z "$_tmux_set_cmds" ]] && return
-    local _tmpfile
-    _tmpfile="$(mktemp)"
-    printf '%s' "$_tmux_set_cmds" > "$_tmpfile"
-    tmux source-file "$_tmpfile"
-    rm -f "$_tmpfile"
+    # tmux 3.0+ supports reading from stdin via 'source-file -'
+    if ! tmux source-file - <<< "$_tmux_set_cmds" 2>/dev/null; then
+        local _tmpfile
+        _tmpfile="$(mktemp)"
+        printf '%s' "$_tmux_set_cmds" > "$_tmpfile"
+        tmux source-file "$_tmpfile"
+        rm -f "$_tmpfile"
+    fi
 }
 
 # Defaults


### PR DESCRIPTION
## Summary
- Use `tmux source-file -` (stdin, tmux 3.0+) to load config, avoiding `mktemp`/`rm` overhead
- Automatically falls back to temp file for older tmux versions

## Test plan
- [x] Verified `tmux source-file - <<< ...` works on tmux 3.6a
- [ ] Verify fallback works on tmux < 3.0 (if available)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance on tmux 3.0+ with streamlined command handling while maintaining backward compatibility with older tmux versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->