### PR TITLE
feat: add configurable window and prefix styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,29 @@ set -g @tmux_power_left_a_style  'bold'  # default
 set -g @tmux_power_right_z_style 'bold'
 ```
 
+Window and prefix-highlight styles are configurable through the same plugin option model:
+
+```tmux
+set -g @tmux_power_window_current_style   'bold'  # default
+set -g @tmux_power_window_last_style      'bold'  # default
+set -g @tmux_power_window_activity_style  'bold'  # default
+set -g @tmux_power_window_bell_style      'bold'  # default
+set -g @tmux_power_prefix_highlight_style 'bold'  # default
+```
+
+To disable bold for the current window, window flags, and prefix highlight:
+
+```tmux
+set -g @tmux_power_window_current_style   'none'
+set -g @tmux_power_window_last_style      'none'
+set -g @tmux_power_window_activity_style  'none'
+set -g @tmux_power_window_bell_style      'none'
+set -g @tmux_power_prefix_highlight_style 'none'
+```
+
+Advanced users can still overwrite native tmux options after the plugin loads, but the
+`@tmux_power_*` settings above are the supported tmux-power interface.
+
 As an example, the following configurations can generate the theme shown in the first screenshot:
 
 ```tmux

--- a/tests/tmux_power_test.sh
+++ b/tests/tmux_power_test.sh
@@ -477,6 +477,42 @@ test_prefix_highlight_position_variants() {
     done
 }
 
+test_window_styles_can_be_configured() {
+    start_tmux
+    set_power_option window_current_style 'underscore'
+    set_power_option window_last_style 'none'
+    set_power_option window_activity_style 'italics'
+    set_power_option window_bell_style 'dim'
+    load_plugin
+
+    local window_current window_last window_activity window_bell
+    window_current="$(run_tmux show -gv window-status-current-format)"
+    window_last="$(run_tmux show -gv window-status-last-style)"
+    window_activity="$(run_tmux show -gv window-status-activity-style)"
+    window_bell="$(run_tmux show -gv window-status-bell-style)"
+
+    assert_contains ',underscore]' "$window_current" \
+        "current window should use window_current_style" || return 1
+    assert_contains ',none' "$window_last" \
+        "last window should use window_last_style" || return 1
+    assert_contains ',italics' "$window_activity" \
+        "activity window should use window_activity_style" || return 1
+    assert_contains ',dim' "$window_bell" \
+        "bell window should use window_bell_style" || return 1
+}
+
+test_prefix_highlight_style_can_be_configured() {
+    start_tmux
+    set_power_option prefix_highlight_style 'none'
+    load_plugin
+
+    local prefix_copy
+    prefix_copy="$(run_tmux show -gv @prefix_highlight_copy_mode_attr)"
+
+    assert_contains ',none' "$prefix_copy" \
+        "prefix highlight should use prefix_highlight_style" || return 1
+}
+
 test_use_bold_option_is_ignored() {
     start_tmux
     set_power_option use_bold false
@@ -533,6 +569,8 @@ main() {
     run_test test_batch_loader_preserves_tmux_and_shell_literals
     run_test test_section_styles_apply_per_section
     run_test test_prefix_highlight_position_variants
+    run_test test_window_styles_can_be_configured
+    run_test test_prefix_highlight_style_can_be_configured
     run_test test_use_bold_option_is_ignored
 
     if ((TESTS_FAILED > 0)); then

--- a/tmux-power.tmux
+++ b/tmux-power.tmux
@@ -31,6 +31,11 @@ set_defaults() {
     right_x_style=''
     right_y_style=''
     right_z_style=''
+    window_current_style='bold'
+    window_last_style='bold'
+    window_activity_style='bold'
+    window_bell_style='bold'
+    prefix_highlight_style='bold'
     theme='gold'
     g0='#262626'
     g1='#303030'
@@ -74,7 +79,7 @@ configure_status_bar() {
     tmux_set status-attr none
 
     tmux_set @prefix_highlight_show_copy_mode 'on'
-    tmux_set @prefix_highlight_copy_mode_attr "fg=$TC,bg=$G0,bold"
+    tmux_set @prefix_highlight_copy_mode_attr "fg=$TC,bg=$G0,$prefix_highlight_style"
     tmux_set @prefix_highlight_output_prefix "#[fg=$TC]#[bg=$G0]$left_arrow_icon#[bg=$TC]#[fg=$G0]"
     tmux_set @prefix_highlight_output_suffix "#[fg=$TC]#[bg=$G0]$right_arrow_icon"
 
@@ -149,12 +154,12 @@ build_right_status() {
 
 configure_ui_styles() {
     tmux_set window-status-format         "#[fg=$G0,bg=$G2]$right_arrow_icon#[fg=$TC,bg=$G2] #I:#W#F #[fg=$G2,bg=$G0]$right_arrow_icon"
-    tmux_set window-status-current-format "#[fg=$G0,bg=$TC]$right_arrow_icon#[fg=$G0,bg=$TC,bold] #I:#W#F #[fg=$TC,bg=$G0,nobold]$right_arrow_icon"
+    tmux_set window-status-current-format "#[fg=$G0,bg=$TC]$right_arrow_icon#[fg=$G0,bg=$TC,$window_current_style] #I:#W#F #[fg=$TC,bg=$G0,none]$right_arrow_icon"
 
     tmux_set window-status-style          "fg=$TC,bg=$G0,none"
-    tmux_set window-status-last-style     "fg=$TC,bg=$G0,bold"
-    tmux_set window-status-activity-style "fg=$TC,bg=$G0,bold"
-    tmux_set window-status-bell-style     "fg=$TC,bg=$G0,bold"
+    tmux_set window-status-last-style     "fg=$TC,bg=$G0,$window_last_style"
+    tmux_set window-status-activity-style "fg=$TC,bg=$G0,$window_activity_style"
+    tmux_set window-status-bell-style     "fg=$TC,bg=$G0,$window_bell_style"
     tmux_set window-status-separator ""
 
     tmux_set pane-border-style "fg=$G3,bg=default"


### PR DESCRIPTION
## Description

Add first-class `@tmux_power_*_style` options for window states and prefix highlight so users can disable or change bold without overriding native tmux options after the plugin loads.

This keeps the plugin configuration model consistent with per-section styles, preserves the current default appearance, and updates the window-current format so arbitrary tmux styles work correctly.

Fixes #71

## Checklist

- [x] Description above explains the change and motivation
- [x] Tested with at least one theme (`gold`, `everforest`, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five configurable styling options for window states and prefix highlighting.
  * Users can now customize or disable bold formatting for these elements.

* **Documentation**
  * Added documentation for new styling configuration options with default values.

* **Tests**
  * Added validation tests for the new style configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->