### PR TITLE
docs(readme): add plugin ordering tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ set -g @tmux_power_status_interval 1  # status bar refresh interval in seconds
 
 Any tmux plugin that exposes `#{...}` format tokens can be placed in a section.
 
+> [!TIP]
+> If you use plugins that post-process `status-left` or `status-right` when they are sourced
+> (for example, `tmux-battery`), load `wfxr/tmux-power` before them in your TPM plugin list.
+
 **[tmux-net-speed](https://github.com/wfxr/tmux-net-speed)**
 
 ```tmux


### PR DESCRIPTION
## Description

Add a README tip about plugin load order for integrations that rewrite tmux status lines when sourced, such as tmux-battery.

Related to #73.

## Checklist

- [x] Description above explains the change and motivation
- [ ] Tested with at least one theme (`gold`, `everforest`, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin configuration guidance to clarify that this plugin should be loaded before other TMux plugins that modify status bar displays to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->